### PR TITLE
Migrate from Potherca to Unicorn Global

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 .gitignore
 _config.yml
 CONTRIBUTING.md
+.snyk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at potherca@gmail.com. All
+reported by contacting the project team at support@unicorn.global. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -96,5 +96,5 @@ version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
-[github]: https://github.com/potherca/liquid-linter-cli/issues
-[prs]: https://github.com/potherca/liquid-linter-cli/pulls
+[github]: https://github.com/UnicornGlobal/liquid-linter-cli/issues
+[prs]: https://github.com/UnicornGlobal/liquid-linter-cli/pulls

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (c) 2017 Dealerdirect
 Copyright (c) 2019 Potherca
+Copyright (c) 2020 Unicorn Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Liquid Linter CLI
 
-![Project Stage][project-stage-shield]
+[![Project Stage][project-stage-shield]][project-stages]
 ![Maintenance][maintenance-shield]
 ![Awesome][awesome-shield]
 [![License][license-shield]](LICENSE.md)
@@ -167,7 +167,8 @@ For a full list off all author and/or contributors, check [the contributors page
 [NPM]: https://www.npmjs.com/
 [pipelines]: https://en.wikipedia.org/wiki/Pipeline_(Unix)
 [potherca]: https://pother.ca/
-[project-stage-shield]: https://img.shields.io/badge/Project%20Stage-Development-yellowgreen.svg
+[project-stage-shield]: https://img.shields.io/badge/Project%20Stage-Production%20Ready-brightgreen.svg
+[project-stages]: https://blog.pother.ca/project-stages/
 [the Noun Project]: https://thenounproject.com/
 [version-shield]: https://img.shields.io/npm/v/liquid-linter-cli.svg
 [version]: https://www.npmjs.com/package/liquid-linter-cli

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For a full list off all author and/or contributors, check [the contributors page
 >
 > Copyright (c) 2017 Dealerdirect B.V. <br>
 > Copyright (c) 2019 Potherca
+> Copyright (c) 2020 Unicorn Global
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -170,5 +171,3 @@ For a full list off all author and/or contributors, check [the contributors page
 [version-shield]: https://img.shields.io/npm/v/liquid-linter-cli.svg
 [version]: https://www.npmjs.com/package/liquid-linter-cli
 [Yarn]: https://yarnpkg.com/
-
-

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For a full list off all author and/or contributors, check [the contributors page
 > The MIT License (MIT)
 >
 > Copyright (c) 2017 Dealerdirect B.V. <br>
-> Copyright (c) 2019 Potherca
+> Copyright (c) 2019 Potherca <br>
 > Copyright (c) 2020 Unicorn Global
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Thank you for being involved! :heart_eyes:
 ## Authors & contributors
 
 The original idea and setup of this repository is by [Potherca][potherca].
+In 2020 active development was taken over by [Unicorn Global](https://unicorn.global/). 
 
 For a full list off all author and/or contributors, check [the contributors page][contributors].
 
@@ -152,17 +153,17 @@ For a full list off all author and/or contributors, check [the contributors page
 [awesome-shield]: https://img.shields.io/badge/awesome%3F-yes-brightgreen.svg
 [Cassie McKown]: https://thenounproject.com/mckowncr/
 [contribution-guidelines]: CONTRIBUTING.md
-[contributors]: https://github.com/potherca/liquid-linter-cli/graphs/contributors
+[contributors]: https://github.com/UnicornGlobal/liquid-linter-cli/graphs/contributors
 [dependency-status]: https://img.shields.io/librariesio/release/npm/liquid-linter-cli.svg
 [gnu-find]: https://www.gnu.org/software/findutils/manual/html_mono/find.html#Top
 [gnu-xargs]: https://www.gnu.org/software/findutils/manual/html_mono/find.html#Invoking-xargs
 [includes]: https://help.shopify.com/themes/liquid/tags/theme-tags#include
 [librariesio]: https://libraries.io/npm/liquid-linter-cli
-[license-shield]: https://img.shields.io/github/license/potherca/liquid-linter-cli.svg
+[license-shield]: https://img.shields.io/github/license/UnicornGlobal/liquid-linter-cli.svg
 [liquid-lint repository]: https://github.com/tomheller/liquid-linter/issues
 [liquid-linter]: https://www.npmjs.com/package/liquid-linter
 [liquid-tags]: https://help.shopify.com/themes/liquid/tags
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2019.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2020.svg
 [NPM]: https://www.npmjs.com/
 [pipelines]: https://en.wikipedia.org/wiki/Pipeline_(Unix)
 [potherca]: https://pother.ca/


### PR DESCRIPTION
This MR changes the docs and license in preparation of migrating this package from its current home at [Potherca/liquid-linter-cli](https://github.com/Potherca/liquid-linter-cli) to [UnicornGlobal/liquid-linter-cli](https://github.com/UnicornGlobal/liquid-linter-cli)