### PR TITLE
Change requirement from @unicorns/liquid-linter to liquid-linter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chalk": "2.4.2",
     "commander": "2.20.0",
     "filehound": "1.17.3",
-    "@unicorns/liquid-linter": "1.0.2",
+    "liquid-linter": "1.0.2",
     "snyk": "^1.316.1"
   },
   "scripts": {


### PR DESCRIPTION
## Proposed Changes

The current `dependencies` sections requires `@unicorns/liquid-linter`, as we are promoting this fork to be the source of truth, it can be changed to `liquid-linter`
